### PR TITLE
newdoc(concepts): intro to webpack 

### DIFF
--- a/content/concepts/core-concepts.md
+++ b/content/concepts/core-concepts.md
@@ -1,0 +1,14 @@
+---
+title: Core Concepts
+---
+
+## Entry, Output, Loaders, Plugins
+
+### Entry
+
+### Output
+
+### Loaders
+
+### Plugins
+

--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -3,7 +3,7 @@ title: Introduction
 ---
 ## Overview
 
-*webpack* is a _module_ _bundler_ for modern JavaScript applications.
+*webpack* is a _module bundler_ for modern JavaScript applications.
 
 ### What is a module?
 
@@ -43,7 +43,7 @@ The webpack community has built _loaders_ for a wide variety of popular language
 
 * [CoffeeScript](http://coffeescript.org)
 * [TypeScript](https://www.typescriptlang.org)
-* [Babel](https://babeljs.io)
+* [ESNext (Babel)](https://babeljs.io)
 * [Sass](http://sass-lang.com)
 * [Less](http://lesscss.org)
 * [Stylus](http://stylus-lang.com)

--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -8,6 +8,7 @@ TODO
 =======
 title: Introduction
 ---
+## Overview
 
 *webpack* is a _module_ _bundler_ for modern JavaScript applications.
 
@@ -28,21 +29,24 @@ webpack builds on lessons learned from these systems and applies the concept of 
 In contrast to Node.js modules, webpack _modules_ can express their _dependencies_ in a variety of ways. A few examples are:
 
 * A JavaScript `require()` statement
-* An ECMAScript2015 `import` statement [^1]
+* An ECMAScript2015 `import` statement
 * An AMD `define` and `require` statement
 * An `@import` statement inside of a css/sass/less file.
 * An image url in a stylesheet or html file. 
 
+T> webpack 1 requires a specific loader to convert ECMAScript2015 `import`, however this is possible out of the box via webpack 2
+
 ### webpack, dependency graph, and bundles
 
-Any time one file depends on another (as seen above), webpack treats this as a _dependency_. This allows webpack to take non-code assets, such as images or web fonts, and also provide them as _dependencies_ for your application.
+Any time one file depends on another, webpack treats this as a _dependency_. This allows webpack to take non-code assets, such as images or web fonts, and also provide them as _dependencies_ for your application.
 
 When webpack processes your application, it starts from a list of modules defined on the command line or in its config file.
-Starting from these _entry points_, webpack recursively builds a _dependency graph_ that includes every module your application needs, then packages all of those modules into a small number of _bundles_ - often, just one - to be loaded by the browser.
-Bundling your application is especially powerful for HTTP/1.1 clients, as it minimizes the number of times your app has to wait while the browser starts a new request. For HTTP/2, you can also use Code Splitting and bundling through webpack for the [best optimization](https://medium.com/webpack/webpack-http-2-7083ec3f3ce6#.7y5d3hz59).
+Starting from these _entry points_, webpack recursively builds a _dependency graph_ that includes every module your application needs, then packages all of those modules into a small number of _bundles_ - often, just one - to be loaded by the browser. 
 
-webpack supports modules written in many languages and preprocessors, via _loaders_. _Loaders_ describe to webpack **how** to process non-javascript _modules_ and include these _dependencies_ into your _bundles_.
-The webpack community has built loaders for a wide variety of popular languages and language processors, including:
+T> Bundling your application is especially powerful for *HTTP/1.1* clients, as it minimizes the number of times your app has to wait while the browser starts a new request. For *HTTP/2*, you can also use Code Splitting and bundling through webpack for the [best optimization](https://medium.com/webpack/webpack-http-2-7083ec3f3ce6#.7y5d3hz59).
+
+webpack supports modules written in a variety of languages and preprocessors, via _loaders_. _Loaders_ describe to webpack **how** to process non-javascript _modules_ and include these _dependencies_ into your _bundles_.
+The webpack community has built _loaders_ for a wide variety of popular languages and language processors, including:
 
 * [CoffeeScript](http://coffeescript.org)
 * [TypeScript](https://www.typescriptlang.org)
@@ -51,8 +55,15 @@ The webpack community has built loaders for a wide variety of popular languages 
 * [Less](http://lesscss.org)
 * [Stylus](http://stylus-lang.com)
 
-And many others.
-For a full list, see **the documentation** (TODO: link to loader list or NPM), or **write your own** (TODO: link to loader tutorial).
+And many others! Overall, webpack provides a powerful and rich API for customization that allows one to use webpack for **any stack**, while staying **unopinionated** about your development, testing, and production workflows. 
 
+For a full list, see [**the list of loaders**](https://webpack.github.io/docs/list-of-loaders.html) or [**write your own**](./api/loaders).
+
+### Recap
+
+<<<<<<< HEAD
 [^1] webpack 1 requires a specific loader to convert ECMAScript2015 `import`, however this is possible out of the box via webpack 2
 >>>>>>> 20df545... Renamed the file to index, as well as clean up a variety of notes.
+=======
+We are just starting to scratch the surface of webpack and its features, but we are equipped with a great grasp on terminology you will frequent throughout this guide. Its time to now dive into the [Core Concepts (Entry, Output, Loaders, Plugins)](./concepts/core-concepts)!
+>>>>>>> 01a48bc... Cleaned up some style added tips for HTTP and added a recap for segue to next doc

--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -1,11 +1,4 @@
 ---
-<<<<<<< HEAD
-title: Concepts
----
-
-TODO
-
-=======
 title: Introduction
 ---
 ## Overview
@@ -61,9 +54,4 @@ For a full list, see [**the list of loaders**](https://webpack.github.io/docs/li
 
 ### Recap
 
-<<<<<<< HEAD
-[^1] webpack 1 requires a specific loader to convert ECMAScript2015 `import`, however this is possible out of the box via webpack 2
->>>>>>> 20df545... Renamed the file to index, as well as clean up a variety of notes.
-=======
 We are just starting to scratch the surface of webpack and its features, but we are equipped with a great grasp on terminology you will frequent throughout this guide. Its time to now dive into the [Core Concepts (Entry, Output, Loaders, Plugins)](./concepts/core-concepts)!
->>>>>>> 01a48bc... Cleaned up some style added tips for HTTP and added a recap for segue to next doc

--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -1,6 +1,58 @@
 ---
+<<<<<<< HEAD
 title: Concepts
 ---
 
 TODO
 
+=======
+title: Introduction
+---
+
+*webpack* is a _module_ _bundler_ for modern JavaScript applications.
+
+### What is a module?
+
+In [modular programming](https://en.wikipedia.org/wiki/Modular_programming), developers break programs up into discrete chunks of functionality called a _module_.
+
+Each module has a smaller surface area than a full program, making verification, debugging, and testing trival. 
+Well-written _modules_ provide solid abstractions and encapsulation boundaries, so that each module has a coherent design and a clear purpose within the overall application.
+
+Node.js has supported modular programming almost since its inception. 
+On the web, however, support for _modules_ has been slow to arrive.
+Multiple tools exist that support modular JavaScript on the web, with a variety of benefits and limitations.
+webpack builds on lessons learned from these systems and applies the concept of _modules_ to any file in your project. 
+
+### What is a webpack module?
+
+In contrast to Node.js modules, webpack _modules_ can express their _dependencies_ in a variety of ways. A few examples are:
+
+* A JavaScript `require()` statement
+* An ECMAScript2015 `import` statement [^1]
+* An AMD `define` and `require` statement
+* An `@import` statement inside of a css/sass/less file.
+* An image url in a stylesheet or html file. 
+
+### webpack, dependency graph, and bundles
+
+Any time one file depends on another (as seen above), webpack treats this as a _dependency_. This allows webpack to take non-code assets, such as images or web fonts, and also provide them as _dependencies_ for your application.
+
+When webpack processes your application, it starts from a list of modules defined on the command line or in its config file.
+Starting from these _entry points_, webpack recursively builds a _dependency graph_ that includes every module your application needs, then packages all of those modules into a small number of _bundles_ - often, just one - to be loaded by the browser.
+Bundling your application is especially powerful for HTTP/1.1 clients, as it minimizes the number of times your app has to wait while the browser starts a new request. For HTTP/2, you can also use Code Splitting and bundling through webpack for the [best optimization](https://medium.com/webpack/webpack-http-2-7083ec3f3ce6#.7y5d3hz59).
+
+webpack supports modules written in many languages and preprocessors, via _loaders_. _Loaders_ describe to webpack **how** to process non-javascript _modules_ and include these _dependencies_ into your _bundles_.
+The webpack community has built loaders for a wide variety of popular languages and language processors, including:
+
+* [CoffeeScript](http://coffeescript.org)
+* [TypeScript](https://www.typescriptlang.org)
+* [Babel](https://babeljs.io)
+* [Sass](http://sass-lang.com)
+* [Less](http://lesscss.org)
+* [Stylus](http://stylus-lang.com)
+
+And many others.
+For a full list, see **the documentation** (TODO: link to loader list or NPM), or **write your own** (TODO: link to loader tutorial).
+
+[^1] webpack 1 requires a specific loader to convert ECMAScript2015 `import`, however this is possible out of the box via webpack 2
+>>>>>>> 20df545... Renamed the file to index, as well as clean up a variety of notes.


### PR DESCRIPTION
This document is the landing page for the "Concepts" section in our docs page. This is most likely going to be one of the first things a first-time user (or any user reads) and should expose to them some abstract/high-level terminology and webpack definitions that will be tossed around throughout the rest of the docs. And will segue into a Core Concepts page. (Which is stubbed for now). 

This corresponds to #38 