### PR TITLE
Documentation for how to develop using Vagrant

### DIFF
--- a/content/how-to/develop-using-vagrant.md
+++ b/content/how-to/develop-using-vagrant.md
@@ -1,0 +1,92 @@
+---
+title: How to Develop using Vagrant
+---
+
+If you have a more advanced project and use [Vagrant](https://www.vagrantup.com/) to run your development environment in a Virtual Machine, you'll often want to also run webpack in the VM.
+
+To start, make sure that the `Vagrantfile` has a static IP;
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.network :private_network, ip: "10.10.10.61"
+end
+```
+
+Next, install webpack and webpack-dev-server in your project;
+
+```
+npm install webpack webpack-dev-server --save-dev
+```
+
+Make sure to have a `webpack.config.js` file. If you haven't already, use this as a minimal example to get started:
+
+```js
+module.exports = {
+  context: __dirname,
+  entry: "./app.js"
+}
+```
+
+And create a `index.html` file. The script tag should point to your bundle. If `output.filename` is not specified in the config, this will be `bundle.js`.
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/bundle.js" charset="utf-8"></script>
+  </head>
+  <body>
+    <h2>Heey!</h2>
+  </body>
+</html>
+```
+
+Note that you also need to create an `app.js` file.
+
+Now, let's run the server:
+
+```
+webpack-dev-server --host 0.0.0.0 --public 10.10.10.61:8080 --watch-poll
+```
+
+By default the server will only be accessible from localhost. We'll be accessing it from our host PC, so we need to change `--host` to allow this.
+
+webpack-dev-server will include a script in your bundle that connects to a websocket to reload when a change in any of your files occurs.
+The `--public` flag makes sure the script knows where to look for the websocket. The server will use port `8080` by default, so we should also specify that here.
+
+`--watch-poll` makes sure that webpack can detect changes in your files. By default webpack listens to events triggered by the filesystem, but VirtualBox has many problems with this.
+
+The server should be accessible on `http://10.10.10.61:8080` now! If you make a change in `app.js`, it should live reload.
+
+## Advanced usage with nginx
+
+To mimick a more production-like environment, it is also possible to proxy the webpack-dev-server with nginx.
+
+In your nginx config file, add the following:
+
+```
+server {
+  location / {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    error_page 502 @start-webpack-dev-server;
+  }
+
+  location @start-webpack-dev-server {
+    default_type text/plain;
+    return 502 "Please start the webpack-dev-server first.";
+  }
+}
+```
+
+The `proxy_set_header` lines are very important, because they allow the websocket to work correctly.
+
+The command to start webpack-dev-server can then be changed to this:
+
+```
+webpack-dev-server --public 10.10.10.61 --watch-poll
+```
+
+This makes the server only accessible on `127.0.0.1`, which is fine, because nginx takes care of making it available on your host PC.

--- a/content/how-to/develop-using-vagrant.md
+++ b/content/how-to/develop-using-vagrant.md
@@ -14,7 +14,7 @@ end
 
 Next, install webpack and webpack-dev-server in your project;
 
-```
+```shell
 npm install webpack webpack-dev-server --save-dev
 ```
 
@@ -45,7 +45,7 @@ Note that you also need to create an `app.js` file.
 
 Now, let's run the server:
 
-```
+```shell
 webpack-dev-server --host 0.0.0.0 --public 10.10.10.61:8080 --watch-poll
 ```
 
@@ -64,7 +64,7 @@ To mimick a more production-like environment, it is also possible to proxy the w
 
 In your nginx config file, add the following:
 
-```
+```nginx
 server {
   location / {
     proxy_pass http://127.0.0.1:8080;

--- a/content/how-to/develop-using-vagrant.md
+++ b/content/how-to/develop-using-vagrant.md
@@ -4,6 +4,8 @@ title: How to Develop using Vagrant
 
 If you have a more advanced project and use [Vagrant](https://www.vagrantup.com/) to run your development environment in a Virtual Machine, you'll often want to also run webpack in the VM.
 
+## Configuring the Project
+
 To start, make sure that the `Vagrantfile` has a static IP;
 
 ```ruby
@@ -43,6 +45,8 @@ And create a `index.html` file. The script tag should point to your bundle. If `
 
 Note that you also need to create an `app.js` file.
 
+## Running the Server
+
 Now, let's run the server:
 
 ```shell
@@ -51,14 +55,14 @@ webpack-dev-server --host 0.0.0.0 --public 10.10.10.61:8080 --watch-poll
 
 By default the server will only be accessible from localhost. We'll be accessing it from our host PC, so we need to change `--host` to allow this.
 
-webpack-dev-server will include a script in your bundle that connects to a websocket to reload when a change in any of your files occurs.
-The `--public` flag makes sure the script knows where to look for the websocket. The server will use port `8080` by default, so we should also specify that here.
+webpack-dev-server will include a script in your bundle that connects to a WebSocket to reload when a change in any of your files occurs.
+The `--public` flag makes sure the script knows where to look for the WebSocket. The server will use port `8080` by default, so we should also specify that here.
 
 `--watch-poll` makes sure that webpack can detect changes in your files. By default webpack listens to events triggered by the filesystem, but VirtualBox has many problems with this.
 
 The server should be accessible on `http://10.10.10.61:8080` now! If you make a change in `app.js`, it should live reload.
 
-## Advanced usage with nginx
+## Advanced Usage with nginx
 
 To mimick a more production-like environment, it is also possible to proxy the webpack-dev-server with nginx.
 
@@ -81,7 +85,7 @@ server {
 }
 ```
 
-The `proxy_set_header` lines are very important, because they allow the websocket to work correctly.
+The `proxy_set_header` lines are very important, because they allow the WebSocket to work correctly.
 
 The command to start webpack-dev-server can then be changed to this:
 
@@ -90,3 +94,7 @@ webpack-dev-server --public 10.10.10.61 --watch-poll
 ```
 
 This makes the server only accessible on `127.0.0.1`, which is fine, because nginx takes care of making it available on your host PC.
+
+## Conclusion
+
+We made the Vagrant box accessible from a static IP, and then made webpack-dev-server publicly accessible so it is reachable from a browser. We then tackled a common problem that VirtualBox doesn't send out filesystem events, causing the server to not reload on file changes.


### PR DESCRIPTION
I documented how you can use webpack-dev-server with Vagrant.

I know it may be not the most important aspect, seeing how much still needs to be done, but I also wanted to get some practice with documenting a how-to. There will be more!

The part I'm not sure about is whether to show a full working `Vagrantfile`. At the moment I show only one config thingy from the `Vagrantfile`.

Related: #26

Sidenote: the contributing guidelines say to create an issue first when creating a new page, but this was already discussed in #26. Is this good enough?